### PR TITLE
Parse season episodes (if they are available)

### DIFF
--- a/src/tv/season.cr
+++ b/src/tv/season.cr
@@ -6,6 +6,7 @@ class Tmdb::Tv::Season
   include PosterUrls
 
   getter air_date : Time?
+  getter episodes : Array(Tv::Episode)?
   getter poster_path : String?
   getter season_number : Int32
   getter id : Int64
@@ -21,6 +22,7 @@ class Tmdb::Tv::Season
 
   def initialize(data : JSON::Any, @show_id : Int64)
     @air_date = Tmdb.parse_date(data["air_date"])
+    @episodes = data["episodes"].as_a.map { |episode| Episode.new(episode, show_id) } if data["episode"]?
     @poster_path = data["poster_path"].as_s?
     @season_number = data["season_number"].as_i
     @id = data["id"].as_i64


### PR DESCRIPTION
Hi,

I noticed that the [season details endpoint](https://developer.themoviedb.org/reference/tv-season-details) returns the list of episodes, but that this library was not parsing it.
![imagem](https://github.com/mmacia/tmdb.cr/assets/237442/80cc9742-6195-4d7a-a853-197c14bff8b5)

I added the field and parsed it, but made the check to see if it is present, since the `Tv::Season` initializer was also being used when retrieving the `Tv::Show` details (which includes a short version of the `Tv::Season` object, without the episodes), so it should continue working in both cases.

I have also ran the specs and they all passed.

This is a pretty simple PR, but if you need me to change anything, please let me know 😄 