### PR TITLE
Season episodes field & GuestStar profile_path fix

### DIFF
--- a/spec/tv/season_spec.cr
+++ b/spec/tv/season_spec.cr
@@ -7,6 +7,8 @@ describe Tmdb::Tv::Season do
         season = Tmdb::Tv::Season.detail(1418, 1)
 
         season.should be_a(Tmdb::Tv::Season)
+        season.episodes.should_not be_nil
+        season.episodes.not_nil!.size.should be > 0
       end
     end
 

--- a/src/tv/guest_star.cr
+++ b/src/tv/guest_star.cr
@@ -17,7 +17,7 @@ class Tmdb::Tv::GuestStar
     @credit_id = data["credit_id"].as_s
     @character = data["character"].as_s
     @order = data["order"].as_i
-    @profile_path = data["profile_path"].as_s
+    @profile_path = data["profile_path"].as_s? if data["profile_path"]?
   end
 
   def credit : Credit

--- a/src/tv/season.cr
+++ b/src/tv/season.cr
@@ -22,7 +22,7 @@ class Tmdb::Tv::Season
 
   def initialize(data : JSON::Any, @show_id : Int64)
     @air_date = Tmdb.parse_date(data["air_date"])
-    @episodes = data["episodes"].as_a.map { |episode| Episode.new(episode, show_id) } if data["episode"]?
+    @episodes = data["episodes"].as_a.map { |episode| Episode.new(episode, show_id) } if data["episodes"]?
     @poster_path = data["poster_path"].as_s?
     @season_number = data["season_number"].as_i
     @id = data["id"].as_i64


### PR DESCRIPTION
Hi again,

I'm sorry, but apparently I've managed to slip a typo into a nearly one-line PR. I'd put `episode` where it should have been `episodes`.

When testing it on my project I also found a bug in the `GuestStar#profile_path` initialization. Even though the type was `String?`, it was always casting it as a `String`, which threw an exception when it was `nil`. I included the `if data["profile_path"]?` to cover the cases when the `profile_path` key is not even present in the JSON, but also changed `as_s` to `as_s?` to cover the cases when the key is present but the value is set to `nil`.

I've added a real simple check on the specs just to make sure the `episodes` variable was being set this time.

Again, sorry for the troubles. 😓 